### PR TITLE
adding sudo package for alpine images

### DIFF
--- a/php/scripts/alpine/packages.sh
+++ b/php/scripts/alpine/packages.sh
@@ -11,6 +11,7 @@ apk add --update --no-cache \
     libzip \
     openssl-dev \
     rsync \
+    sudo \
     autoconf \
     gcc \
     g++


### PR DESCRIPTION
Fix problem with install custom packages for php in alpine images.

$ apk --update add php7-simplexml php7-fileinfo
ERROR: Unable to lock database: Permission denied
ERROR: Failed to open apk database: Permission denied
ERROR: Job failed: exit code 1