### PR TITLE
Add xdebug to 7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ## Based on [Official PHP images](https://hub.docker.com/_/php/)
 
-> PHP 7.2 is available but yet without xDebug support.
+> PHP 7.2 is available.
 
 - ```7```, ```7.2```, ```latest``` [(7.2/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.2/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.2.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.2 "Get your own image badge on microbadger.com")
 - ```7.2-alpine``` [(7.2/alpine/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.2/alpine/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.2-alpine.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.2-alpine "Get your own image badge on microbadger.com")
@@ -131,7 +131,7 @@ Recommended
 
 Special thanks to [Ambientum](https://github.com/codecasts/ambientum), an incredible Brazilian project, for the inspiration.
 
-Also https://github.com/Chialab/docker-php for php 7.2 build scripts 
+Also https://github.com/Chialab/docker-php for php 7.2 build scripts
 
 [![forthebadge](http://forthebadge.com/images/badges/built-by-developers.svg)](http://forthebadge.com)
 [![forthebadge](http://forthebadge.com/images/badges/powered-by-netflix.svg)](http://forthebadge.com)

--- a/goss-7.2.yaml
+++ b/goss-7.2.yaml
@@ -49,6 +49,7 @@ command:
       - imap
       - xml
       - xmlrpc
+      - xdebug
       - exif
       - imagick
 

--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -54,7 +54,13 @@ if [[ $PHP_VERSION =~ "7.0" ]]; then
 fi
 
 if [[ $PHP_VERSION =~ "7.2" ]]; then
-  echo "PHP 7.2"
+  git clone --depth 1 "https://github.com/xdebug/xdebug" \
+    && cd xdebug \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && docker-php-ext-enable xdebug
 else
   apk --update --no-cache add \
     libmcrypt-dev \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -63,8 +63,8 @@ if [[ $PHP_VERSION =~ "7.2" ]]; then
     && docker-php-source delete \
 
   pecl channel-update pecl.php.net \
-    && pecl install redis apcu mongodb imagick \
-    && docker-php-ext-enable redis apcu mongodb imagick
+    && pecl install redis apcu mongodb imagick xdebug \
+    && docker-php-ext-enable redis apcu mongodb imagick xdebug
 else
   apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y mcrypt
   docker-php-ext-install -j$(nproc) mcrypt


### PR DESCRIPTION
[xdebug support for 7.2 has landed](https://xdebug.org/#2018_01_29). This attempts to add xdebug into the `7.2` container....image...thing 😅

I am new to Docker - so please do check over my PR. Wasn't 100% sure on the `php/scripts/alpine/extensions.sh`. I just duplicated the `7.1` code for that. Hopefully it is pretty close to right. Happy to make any required changes for ya.