### PR TITLE
Alpine: re-add openssh-client

### DIFF
--- a/php/scripts/alpine/packages.sh
+++ b/php/scripts/alpine/packages.sh
@@ -15,7 +15,7 @@ apk add --no-cache \
     rsync \
     sudo
 
-apk add --no-cache openssl openssl-dev
+apk add --no-cache openssl openssl-dev openssh-client
 
 apk add --no-cache --virtual .build-deps build-base autoconf
 


### PR DESCRIPTION
Due to changes in 8a107f76ec74e1fa4e763a2660f3482d2692ff79 the
openssh-client which provides ssh-agent, ssh-add, ... was removed.

Since the image must work with SSH connections, this is a requirement.