### PR TITLE
Update Node version statement to 12

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@
 - ```7.1-alpine-lts``` [(7.1/alpine/Dockerfile-lts)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.1/alpine/Dockerfile-lts) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.1-alpine-lts.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.1-alpine-lts "Get your own image badge on microbadger.com")
 - ```7.1-fpm``` [(7.1/fpm/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.1/fpm/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.1-fpm.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.1-fpm "Get your own image badge on microbadger.com")
 
-All versions (except `lts`) come with [Node 11](https://nodejs.org/en/), [Composer](https://getcomposer.org/) and [Yarn](https://yarnpkg.com)
+All versions (except `lts`) come with [Node 12](https://nodejs.org/en/), [Composer](https://getcomposer.org/) and [Yarn](https://yarnpkg.com)
 
 > `lts` version come with node v10
 


### PR DESCRIPTION
Hi, thanks for the awesome Docker images. 

I noticed that recently you updated Node to version 12 (as some of our builds started to fail). 

In this pull request I changed the Node version statement on the readme file to highlight this change as it was still reporting version 11.