### PR TITLE
Add cassandra extension

### DIFF
--- a/goss-7.2-3-lts.yaml
+++ b/goss-7.2-3-lts.yaml
@@ -38,6 +38,7 @@ command:
       - bcmath
       - bz2
       - calendar
+      - cassandra
       - exif
       - gd
       - iconv

--- a/goss-7.2-3.yaml
+++ b/goss-7.2-3.yaml
@@ -38,6 +38,7 @@ command:
       - bcmath
       - bz2
       - calendar
+      - cassandra
       - exif
       - gd
       - iconv

--- a/goss-lts.yaml
+++ b/goss-lts.yaml
@@ -42,6 +42,7 @@ command:
       - bcmath
       - bz2
       - calendar
+      - cassandra
       - exif
       - gd
       - iconv

--- a/goss.yaml
+++ b/goss.yaml
@@ -42,6 +42,7 @@ command:
       - bcmath
       - bz2
       - calendar
+      - cassandra
       - exif
       - gd
       - iconv

--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -108,8 +108,8 @@ docker-php-source extract \
     && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
     && tar xfz /tmp/cassandra.tar.gz \
     && rm -r /tmp/cassandra.tar.gz \
-    && mv php-driver-*/ext /usr/src/php/ext/cassandra \
-    && rm -rf php-driver-* \
+    && mv php-driver-1.3.2/ext /usr/src/php/ext/cassandra \
+    && rm -rf php-driver-1.3.2 \
     && docker-php-ext-install cassandra \
     && apk del .cassandra-deps \
     && docker-php-source delete

--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -5,6 +5,7 @@ set -euf -o pipefail
 apk --update --no-cache add \
   bzip2 \
   bzip2-dev \
+  cassandra-cpp-driver \
   curl-dev \
   cyrus-sasl-dev \
   freetype-dev \
@@ -100,6 +101,17 @@ docker-php-source extract \
     && pecl install apcu \
     && docker-php-ext-enable apcu \
     && apk del .phpize-deps-configure \
+    && docker-php-source delete
+
+docker-php-source extract \
+    && apk add --no-cache --virtual .cassandra-deps libressl-dev libuv-dev cassandra-cpp-driver-dev \
+    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
+    && tar xfz /tmp/cassandra.tar.gz \
+    && rm -r /tmp/cassandra.tar.gz \
+    && mv php-driver-*/ext /usr/src/php/ext/cassandra \
+    && rm -rf php-driver-* \
+    && docker-php-ext-install cassandra \
+    && apk del .cassandra-deps \
     && docker-php-source delete
 
 pecl install imagick \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -27,10 +27,13 @@ if [[ $PHP_VERSION == "7.3" || $PHP_VERSION == "7.2" ]]; then
     default-libmysqlclient-dev \
     libbz2-dev \
     libsasl2-dev \
+    libuv1-dev \
+    multiarch-support \
     " \
   runtimeDeps=" \
     imagemagick \
     libfreetype6-dev \
+    libgmp-dev \
     libicu-dev \
     libjpeg-dev \
     libkrb5-dev \
@@ -50,10 +53,13 @@ else
     default-libmysqlclient-dev \
     libbz2-dev \
     libsasl2-dev \
+    libuv1-dev \
+    multiarch-support \
     " \
   runtimeDeps=" \
     imagemagick \
     libfreetype6-dev \
+    libgmp-dev \
     libicu-dev \
     libjpeg-dev \
     libkrb5-dev \
@@ -81,6 +87,19 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yqq $buildDeps \
   && docker-php-ext-configure imap --with-kerberos --with-imap-ssl \
   && docker-php-ext-install -j$(nproc) imap \
   && docker-php-source delete
+
+docker-php-source extract \
+    && curl -L -o /tmp/cassandra-cpp-driver.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver_2.14.0-1_amd64.deb" \
+    && curl -L -o /tmp/cassandra-cpp-driver-dev.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver-dev_2.14.0-1_amd64.deb" \
+    && dpkg -i /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
+    && rm /tmp/cassandra-cpp-driver*.deb \
+    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
+    && tar xfz /tmp/cassandra.tar.gz \
+    && rm -r /tmp/cassandra.tar.gz \
+    && mv php-driver-*/ext /usr/src/php/ext/cassandra \
+    && rm -rf php-driver-* \
+    && docker-php-ext-install cassandra \
+    && docker-php-source delete
 
 if [[ $PHP_VERSION == "7.2" ]]; then
   docker-php-source extract \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -96,8 +96,8 @@ docker-php-source extract \
     && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
     && tar xfz /tmp/cassandra.tar.gz \
     && rm -r /tmp/cassandra.tar.gz \
-    && mv php-driver-*/ext /usr/src/php/ext/cassandra \
-    && rm -rf php-driver-* \
+    && mv php-driver-1.3.2/ext /usr/src/php/ext/cassandra \
+    && rm -rf php-driver-1.3.2 \
     && docker-php-ext-install cassandra \
     && docker-php-source delete
 


### PR DESCRIPTION
Hello.

We at our company use your images for CI processes and we lack this extension to run functional tests with the Cassandra database.

~~I suspect that the `docker-php-ext-install` command for some reason doesn't activate the extension (as if it doesn't see the `PHP_INI_DIR` env variable), so it may need to be replaced with the manual `make` and `make install`.~~

IDK about `multiarch-support`. Without it, I cannot install the deb package `cassandra-cpp-driver`. I [tried to compile the extension locally](https://github.com/datastax/php-driver/blob/master/ext/README.md#manually-build-and-install-1), but there were also errors, so I preferred this option. Tell me if this lib is not acceptable, I will look for a way to compile the extension.

Tell me if I need to modify the implementation somewhere.