### PR TITLE
Add mongo-clients

### DIFF
--- a/php/scripts/packages.sh
+++ b/php/scripts/packages.sh
@@ -31,6 +31,7 @@ DEBIAN_FRONTEND=noninteractive
       jq \
       libc-client-dev \
       mariadb-client \
+      mongo-tools \
       openssh-client \
       python \
       python-dev \


### PR DESCRIPTION
This would provide similar benefits as mariadb-client, but for MongoDB.

A use-case would be using `mongodump` and `mongorestore` to dump / restore an image to a MongoDB container etc. 

I added it, since i needed it in my pipeline, and i am sure many others would also be happy to have them. Also the package is pretty small and MongoDB is pretty popular today in a web tech-stack.

**This only adds mongo-tools to the debian builds, for alpine, mongodb-tools is currently still in non-free ([see here](https://gitlab.alpinelinux.org/alpine/aports/issues/10994))**

Thank you