### PR TITLE
Upgrade cassandra extension to be compatible with PHP 7.4

### DIFF
--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -110,6 +110,7 @@ docker-php-source extract \
     && mkdir /tmp/cassandra \
     && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
     && rm -r /tmp/cassandra.tar.gz \
+    && curl -L "https://github.com/datastax/php-driver/pull/135.patch" | patch -p1 -d /tmp/cassandra -i - \
     && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
     && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \

--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -106,11 +106,12 @@ docker-php-source extract \
 
 docker-php-source extract \
     && apk add --no-cache --virtual .cassandra-deps libressl-dev libuv-dev cassandra-cpp-driver-dev \
-    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
-    && tar xfz /tmp/cassandra.tar.gz \
+    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/24d85d9f1d.tar.gz" \
+    && mkdir /tmp/cassandra \
+    && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
     && rm -r /tmp/cassandra.tar.gz \
-    && mv php-driver-1.3.2/ext /usr/src/php/ext/cassandra \
-    && rm -rf php-driver-1.3.2 \
+    && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
+    && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \
     && apk del .cassandra-deps \
     && docker-php-source delete

--- a/php/scripts/alpine/packages.sh
+++ b/php/scripts/alpine/packages.sh
@@ -14,6 +14,7 @@ apk update \
     mariadb-client \
     openssh-client \
     openssl \
+    patch \
     python \
     rsync \
     sudo \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -109,6 +109,7 @@ docker-php-source extract \
     && mkdir /tmp/cassandra \
     && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
     && rm -r /tmp/cassandra.tar.gz \
+    && curl -L "https://github.com/datastax/php-driver/pull/135.patch" | patch -p1 -d /tmp/cassandra -i - \
     && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
     && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -105,11 +105,12 @@ docker-php-source extract \
     && curl -L -o /tmp/cassandra-cpp-driver-dev.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver-dev_2.14.0-1_amd64.deb" \
     && dpkg -i /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
     && rm /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
-    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/v1.3.2.tar.gz" \
-    && tar xfz /tmp/cassandra.tar.gz \
+    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/24d85d9f1d.tar.gz" \
+    && mkdir /tmp/cassandra \
+    && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
     && rm -r /tmp/cassandra.tar.gz \
-    && mv php-driver-1.3.2/ext /usr/src/php/ext/cassandra \
-    && rm -rf php-driver-1.3.2 \
+    && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
+    && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \
     && docker-php-source delete
 

--- a/tests/goss-7.4.yaml
+++ b/tests/goss-7.4.yaml
@@ -42,6 +42,7 @@ command:
       - bcmath
       - bz2
       - calendar
+      - cassandra
       - exif
       - gd
       - iconv


### PR DESCRIPTION
The extension doesn't work on alpine at the moment. It seems that among all the libraries the extension is built with it does not find PHP itself :)

![](https://erickskrauch.ely.by/monosnap-03-01-2020-at-21-33-56.png)

The build for Debian is going well.