### PR TITLE
Add PHP xsl extension

### DIFF
--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -45,7 +45,7 @@ docker-php-ext-configure ldap
 docker-php-ext-install -j "$(nproc)" ldap
 PHP_OPENSSL=yes docker-php-ext-configure imap --with-kerberos --with-imap-ssl
 docker-php-ext-install -j "$(nproc)" imap
-docker-php-ext-install -j "$(nproc)" exif xmlrpc pcntl bcmath bz2 calendar intl mysqli opcache pdo_mysql pdo_pgsql pgsql soap zip
+docker-php-ext-install -j "$(nproc)" exif xmlrpc pcntl bcmath bz2 calendar intl mysqli opcache pdo_mysql pdo_pgsql pgsql soap xsl zip
 docker-php-source delete
 
 if [[ $PHP_VERSION == "7.4" ]]; then

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -45,6 +45,7 @@ if [[ $PHP_VERSION == "7.4" || $PHP_VERSION == "7.3" || $PHP_VERSION == "7.2" ]]
     libuv1-dev \
     libxml2-dev \
     libzip-dev \
+    libxslt1-dev \
     multiarch-support \
     "
 else

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -16,6 +16,7 @@ pdo_pgsql \
 pgsql \
 soap \
 xmlrpc \
+xsl \
 zip
 "
 


### PR DESCRIPTION
As more mails are migrating to inky framework, and therefor `lorenzo/pinky` is being used.
`lorenzo/pinky` does require `ext-xsl` to be installed.