### PR TITLE
Avoid libgbm error

### DIFF
--- a/php/scripts/chromium.sh
+++ b/php/scripts/chromium.sh
@@ -7,6 +7,7 @@ DEBIAN_FRONTEND=noninteractive apt-get install -yqq \
     libgconf-2-4 \
     libnss3 \
     libxi6 \
+    libgbm-dev \
     wget \
     xvfb
 


### PR DESCRIPTION
Avoid libgbm error during Chromium startup by installing that dependancy at build time.

Otherwise, I get that kind of errors in my pipeline :

```
Error: Failed to launch the browser process!
/drone/src/node_modules/puppeteer/.local-chromium/linux-737027/chrome-linux/chrome: error while loading shared libraries: libgbm.so.1: cannot open shared object file: No such file or directory
```