### PR TITLE
Use stable xdebug

### DIFF
--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -140,7 +140,7 @@ elif [[ $PHP_VERSION == "7.4" || $PHP_VERSION == "7.3" ]]; then
     && docker-php-source delete
 
   pecl channel-update pecl.php.net \
-    && pecl install amqp redis apcu mongodb imagick xdebug-beta \
+    && pecl install amqp redis apcu mongodb imagick xdebug \
     && docker-php-ext-enable amqp redis apcu mongodb imagick xdebug
 
 else


### PR DESCRIPTION
The xdebug version 3.0.0beta1 causes a segmentation fault. This change should fix #105.