### PR TITLE
Add PHP 8.0 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@
 
 ## Based on [Official PHP images](https://hub.docker.com/_/php/)
 
-> PHP 7.4 available
+> PHP 8.0 available
 
-- ```7.4```, ```7```, ```latest``` [(7.4/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.4/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.4.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.4 "Get your own image badge on microbadger.com")
+- ```8.0```, ```8```, ```latest``` [(8.0/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/8.0/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:8.0.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:8.0 "Get your own image badge on microbadger.com")
+
+- ```8.0-alpine```, ```alpine``` [(8.0/alpine/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/8.0/alpine/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:8.0-alpine.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:8.0-alpine "Get your own image badge on microbadger.com")
+
+
+- ```8.0-fpm```, ```fpm``` [(8.0/fpm/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/8.0/fpm/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:8.0-fpm.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:8.0-fpm "Get your own image badge on microbadger.com")
+
+- ```7.4```, ```7``` [(7.4/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.4/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.4.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.4 "Get your own image badge on microbadger.com")
 
 - ```7.4-alpine```, ```alpine``` [(7.4/alpine/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.4/alpine/Dockerfile) - [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.4-alpine.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.4-alpine "Get your own image badge on microbadger.com")
 
@@ -52,6 +59,7 @@ Everything you need to test Laravel projects :D
 
 To run Dusk tests we need chromium installed on the image, because of that we have a special tag for this case.
 
+- ```8.0-chromium``` [(8.0/chromium/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/8.0/chromium/Dockerfile) [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:8.0-chromium.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:8.0-chromium "Get your own image badge on microbadger.com")
 - ```7.4-chromium``` [(7.4/chromium/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.4/chromium/Dockerfile) [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.4-chromium.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.4-chromium "Get your own image badge on microbadger.com")
 - ```7.3-chromium``` [(7.3/chromium/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.3/chromium/Dockerfile) [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.3-chromium.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.3-chromium "Get your own image badge on microbadger.com")
 - ```7.2-chromium``` [(7.2/chromium/Dockerfile)](https://github.com/edbizarro/gitlab-ci-pipeline-php/blob/master/php/7.2/chromium/Dockerfile) [![](https://images.microbadger.com/badges/image/edbizarro/gitlab-ci-pipeline-php:7.2-chromium.svg)](https://microbadger.com/images/edbizarro/gitlab-ci-pipeline-php:7.2-chromium "Get your own image badge on microbadger.com")
@@ -79,7 +87,7 @@ test:
   stage: test
   services:
     - mysql:5.7
-  image: edbizarro/gitlab-ci-pipeline-php:7.4-alpine
+  image: edbizarro/gitlab-ci-pipeline-php:8.0-alpine
   script:
     - yarn install --pure-lockfile
     - composer install --prefer-dist --no-ansi --no-interaction --no-progress
@@ -118,7 +126,7 @@ test:
   stage: test
   services:
     - mysql:5.7
-  image: edbizarro/gitlab-ci-pipeline-php:7.4-alpine
+  image: edbizarro/gitlab-ci-pipeline-php:8.0-alpine
   script:
     - yarn config set cache-folder .yarn
     - yarn install --pure-lockfile
@@ -135,7 +143,7 @@ test:
 
 deploy:
   stage: deploy
-  image: edbizarro/gitlab-ci-pipeline-php:7.4-alpine
+  image: edbizarro/gitlab-ci-pipeline-php:8.0-alpine
   script:
     - echo "Deploy all the things!"
   only:
@@ -171,7 +179,7 @@ test:
   stage: test
   services:
     - mysql:5.7
-  image: edbizarro/gitlab-ci-pipeline-php:7.4-chromium
+  image: edbizarro/gitlab-ci-pipeline-php:8.0-chromium
   script:
     - yarn config set cache-folder .yarn
     - yarn install --pure-lockfile

--- a/php/8.0/Dockerfile
+++ b/php/8.0/Dockerfile
@@ -1,0 +1,50 @@
+FROM php:8.0
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL maintainer="Eduardo Bizarro <edbizarro@gmail.com>" \
+  PHP="8.0" \
+  NODE="14" \
+  org.label-schema.name="edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.description=":coffee: Docker images for build and test PHP applications with Gitlab CI (or any other CI plataform!)" \
+  org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vcs-url="https://github.com/edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.vcs-ref=$VCS_REF
+
+# Set correct environment variables
+ENV IMAGE_USER=php
+ENV HOME=/home/$IMAGE_USER
+ENV COMPOSER_HOME=$HOME/.composer
+ENV PATH=$HOME/.yarn/bin:$PATH
+ENV GOSS_VERSION="0.3.8"
+ENV PHP_VERSION=8.0
+
+USER root
+
+WORKDIR /tmp
+
+# COPY INSTALL SCRIPTS
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+COPY ./php/scripts/*.sh /tmp/
+RUN chmod +x /tmp/*.sh
+
+# Install2
+RUN bash ./packages.sh \
+  && bash ./extensions.sh \
+  && bash ./node.sh \
+  && adduser --disabled-password --gecos "" $IMAGE_USER && \
+  echo "PATH=$(yarn global bin):$PATH" >> /root/.profile && \
+  echo "PATH=$(yarn global bin):$PATH" >> /root/.bashrc && \
+  echo "$IMAGE_USER  ALL = ( ALL ) NOPASSWD: ALL" >> /etc/sudoers && \
+  mkdir -p /var/www/html \
+  && composer global require "hirak/prestissimo:^0.3"  \
+  && rm -rf ~/.composer/cache/* \
+  && chown -R $IMAGE_USER:$IMAGE_USER /var/www $HOME \
+  && curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh \
+  && bash ./cleanup.sh
+
+USER $IMAGE_USER
+
+WORKDIR /var/www/html

--- a/php/8.0/alpine/Dockerfile
+++ b/php/8.0/alpine/Dockerfile
@@ -1,0 +1,53 @@
+FROM php:8.0-alpine
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL maintainer="Eduardo Bizarro <edbizarro@gmail.com>" \
+  PHP="8.0" \
+  NODE="14" \
+  org.label-schema.name="edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.description=":coffee: Docker images for build and test PHP applications with Gitlab CI (or any other CI plataform!)" \
+  org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vcs-url="https://github.com/edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.vcs-ref=$VCS_REF
+
+# Set correct environment variables
+ENV IMAGE_USER=php
+ENV HOME=/home/$IMAGE_USER
+ENV COMPOSER_HOME=$HOME/.composer
+ENV PATH=$HOME/.yarn/bin:$PATH
+ENV GOSS_VERSION=0.3.8
+ENV NODE_VERSION=14
+ENV NPM_VERSION=6
+ENV YARN_VERSION=latest
+ENV PHP_VERSION=8.0
+
+WORKDIR /tmp
+
+COPY ./php/scripts/alpine/*.sh /tmp/
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+COPY --from=mhart/alpine-node:14 /usr/bin/node /usr/bin/
+COPY --from=mhart/alpine-node:14 /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/* /usr/lib/
+
+# COPY INSTALL SCRIPTS
+RUN chmod +x /tmp/*.sh \
+  && adduser -D $IMAGE_USER \
+  && mkdir -p /var/www/html \
+  && apk add --update --no-cache bash \
+  && bash ./packages.sh \
+  && bash ./extensions.sh \
+  && bash ./nodeyarn.sh \
+  && composer global require "hirak/prestissimo:^0.3" \
+  && rm -rf ~/.composer/cache/* \
+  && chown -R $IMAGE_USER:$IMAGE_USER /var/www $HOME \
+  && echo "$IMAGE_USER  ALL = ( ALL ) NOPASSWD: ALL" >> /etc/sudoers \
+  && curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh \
+  && bash ./cleanup.sh
+
+USER $IMAGE_USER
+
+WORKDIR /var/www/html
+
+CMD ["php", "-a"]

--- a/php/8.0/alpine/Dockerfile-lts
+++ b/php/8.0/alpine/Dockerfile-lts
@@ -1,0 +1,53 @@
+FROM php:8.0-alpine
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL maintainer="Eduardo Bizarro <edbizarro@gmail.com>" \
+      PHP="8.0" \
+      NODE="14.15.0" \
+      org.label-schema.name="edbizarro/gitlab-ci-pipeline-php" \
+      org.label-schema.description=":coffee: Docker images for build and test PHP applications with Gitlab CI (or any other CI plataform!)" \
+      org.label-schema.build-date=$BUILD_DATE \
+      org.label-schema.schema-version="1.0" \
+      org.label-schema.vcs-url="https://github.com/edbizarro/gitlab-ci-pipeline-php" \
+      org.label-schema.vcs-ref=$VCS_REF
+
+# Set correct environment variables
+ENV IMAGE_USER=php
+ENV HOME=/home/$IMAGE_USER
+ENV COMPOSER_HOME=$HOME/.composer
+ENV PATH=$HOME/.yarn/bin:$PATH
+ENV GOSS_VERSION="0.3.8"
+ENV NODE_VERSION="14"
+ENV NPM_VERSION=6
+ENV YARN_VERSION=latest
+ENV PHP_VERSION=8.0
+
+WORKDIR /tmp
+
+# COPY INSTALL SCRIPTS
+COPY ./php/scripts/alpine/*.sh /tmp/
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+COPY --from=mhart/alpine-node:14 /usr/bin/node /usr/bin/
+COPY --from=mhart/alpine-node:14 /usr/lib/libgcc* /usr/lib/libstdc* /usr/lib/* /usr/lib/
+
+RUN chmod +x /tmp/*.sh \
+    && adduser -D $IMAGE_USER \
+    && mkdir -p /var/www/html \
+    && apk add --update --no-cache bash \
+    && bash ./packages.sh \
+    && bash ./extensions.sh \
+    && bash ./nodeyarn.sh \
+    && composer global require "hirak/prestissimo:^0.3" \
+    && rm -rf ~/.composer/cache/* \
+    && chown -R $IMAGE_USER:$IMAGE_USER /var/www $HOME \
+    && echo "$IMAGE_USER  ALL = ( ALL ) NOPASSWD: ALL" >> /etc/sudoers \
+    && curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh \
+    && bash ./cleanup.sh
+
+USER $IMAGE_USER
+
+WORKDIR /var/www/html
+
+CMD ["php", "-a"]

--- a/php/8.0/chromium/Dockerfile
+++ b/php/8.0/chromium/Dockerfile
@@ -1,0 +1,36 @@
+FROM edbizarro/gitlab-ci-pipeline-php:8.0
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL maintainer="Eduardo Bizarro <edbizarro@gmail.com>" \
+  PHP="8.0" \
+  NODE="14" \
+  org.label-schema.name="edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.description=":coffee: Docker images for build and test PHP applications with Gitlab CI (or any other CI plataform!)" \
+  org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vcs-url="https://github.com/edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.vcs-ref=$VCS_REF
+
+# Set correct environment variables
+ENV IMAGE_USER=php
+ENV HOME=/home/$IMAGE_USER
+ENV COMPOSER_HOME=$HOME/.composer
+ENV PATH=$HOME/.yarn/bin:$PATH
+ENV GOSS_VERSION="0.3.8"
+ENV PHP_VERSION=8.0
+
+USER root
+
+WORKDIR /tmp
+
+COPY ./php/scripts/*.sh /tmp/
+RUN chmod +x /tmp/*.sh
+
+RUN bash ./packages.sh \
+  && bash ./chromium.sh
+
+USER $IMAGE_USER
+
+WORKDIR /var/www/html

--- a/php/8.0/fpm/Dockerfile
+++ b/php/8.0/fpm/Dockerfile
@@ -1,0 +1,49 @@
+FROM php:8.0-fpm
+
+ARG BUILD_DATE
+ARG VCS_REF
+
+LABEL maintainer="Eduardo Bizarro <edbizarro@gmail.com>" \
+  PHP="8.0" \
+  NODE="14" \
+  org.label-schema.name="edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.description=":coffee: Docker images for build and test PHP applications with Gitlab CI (or any other CI plataform!)" \
+  org.label-schema.build-date=$BUILD_DATE \
+  org.label-schema.schema-version="1.0" \
+  org.label-schema.vcs-url="https://github.com/edbizarro/gitlab-ci-pipeline-php" \
+  org.label-schema.vcs-ref=$VCS_REF
+
+# Set correct environment variables
+ENV IMAGE_USER=php
+ENV HOME=/home/$IMAGE_USER
+ENV COMPOSER_HOME=$HOME/.composer
+ENV PATH=$HOME/.yarn/bin:$PATH
+ENV GOSS_VERSION="0.3.8"
+ENV PHP_VERSION=8.0
+
+USER root
+
+WORKDIR /tmp
+
+# COPY INSTALL SCRIPTS
+COPY --from=composer:1 /usr/bin/composer /usr/bin/composer
+COPY ./php/scripts/*.sh /tmp/
+RUN chmod +x /tmp/*.sh
+
+# Install
+RUN bash ./packages.sh \
+  && bash ./extensions.sh \
+  && bash ./node.sh \
+  && adduser --disabled-password --gecos "" $IMAGE_USER && \
+  echo "$IMAGE_USER  ALL = ( ALL ) NOPASSWD: ALL" >> /etc/sudoers && \
+  mkdir -p /var/www/html && \
+  chown -R $IMAGE_USER:$IMAGE_USER /var/www $HOME \
+  && composer global require "hirak/prestissimo:^0.3"  \
+  && rm -rf ~/.composer/cache/* \
+  && chown -R $IMAGE_USER:$IMAGE_USER $COMPOSER_HOME \
+  && curl -fsSL https://goss.rocks/install | GOSS_VER=v${GOSS_VERSION} sh \
+  && bash ./cleanup.sh
+
+USER $IMAGE_USER
+
+WORKDIR /var/www/html

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -2,85 +2,103 @@
 
 set -euo pipefail
 
-export extensions=" \
-  bcmath \
-  bz2 \
-  calendar \
-  exif \
-  gmp \
-  intl \
-  mysqli \
-  opcache \
-  pcntl \
-  pdo_mysql \
-  pdo_pgsql \
-  pgsql \
-  soap \
-  xmlrpc \
-  xsl \
-  zip
-  "
-
-if [[ $PHP_VERSION == "7.4" || $PHP_VERSION == "7.3" || $PHP_VERSION == "7.2" ]]; then
-
-export buildDeps=" \
-    default-libmysqlclient-dev \
-    libbz2-dev \
-    libsasl2-dev \
-    pkg-config \
-    "
-
-export runtimeDeps=" \
-    imagemagick \
-    libfreetype6-dev \
-    libgmp-dev \
-    libicu-dev \
-    libjpeg-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmemcached-dev \
-    libmemcachedutil2 \
-    libpng-dev \
-    libpq-dev \
-    librabbitmq-dev \
-    libssl-dev \
-    libuv1-dev \
-    libwebp-dev \
-    libxml2-dev \
-    libxslt1-dev \
-    libzip-dev \
-    multiarch-support \
+if [[ $PHP_VERSION == "8.0" ]]; then
+  export extensions=" \
+    bcmath \
+    bz2 \
+    calendar \
+    exif \
+    gmp \
+    intl \
+    mysqli \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    pgsql \
+    soap \
+    xsl \
+    zip
     "
 else
-
-export buildDeps=" \
-    default-libmysqlclient-dev \
-    libbz2-dev \
-    libsasl2-dev \
+  export extensions=" \
+    bcmath \
+    bz2 \
+    calendar \
+    exif \
+    gmp \
+    intl \
+    mysqli \
+    opcache \
+    pcntl \
+    pdo_mysql \
+    pdo_pgsql \
+    pgsql \
+    soap \
+    xmlrpc \
+    xsl \
+    zip
     "
+fi
 
-export runtimeDeps=" \
-    imagemagick \
-    libfreetype6-dev \
-    libgmp-dev \
-    libicu-dev \
-    libjpeg-dev \
-    libkrb5-dev \
-    libldap2-dev \
-    libmagickwand-dev \
-    libmcrypt-dev \
-    libmemcached-dev \
-    libmemcachedutil2 \
-    libpng-dev \
-    libpq-dev \
-    librabbitmq-dev \
-    libuv1-dev \
-    libwebp-dev \
-    libxml2-dev \
-    mcrypt \
-    multiarch-support \
-    "
+if [[ $PHP_VERSION == "8.0" || $PHP_VERSION == "7.4" || $PHP_VERSION == "7.3" || $PHP_VERSION == "7.2" ]]; then
+  export buildDeps=" \
+      default-libmysqlclient-dev \
+      libbz2-dev \
+      libsasl2-dev \
+      pkg-config \
+      "
+
+  export runtimeDeps=" \
+      imagemagick \
+      libfreetype6-dev \
+      libgmp-dev \
+      libicu-dev \
+      libjpeg-dev \
+      libkrb5-dev \
+      libldap2-dev \
+      libmagickwand-dev \
+      libmemcached-dev \
+      libmemcachedutil2 \
+      libpng-dev \
+      libpq-dev \
+      librabbitmq-dev \
+      libssl-dev \
+      libuv1-dev \
+      libwebp-dev \
+      libxml2-dev \
+      libxslt1-dev \
+      libzip-dev \
+      multiarch-support \
+      "
+else
+  export buildDeps=" \
+      default-libmysqlclient-dev \
+      libbz2-dev \
+      libsasl2-dev \
+      "
+
+  export runtimeDeps=" \
+      imagemagick \
+      libfreetype6-dev \
+      libgmp-dev \
+      libicu-dev \
+      libjpeg-dev \
+      libkrb5-dev \
+      libldap2-dev \
+      libmagickwand-dev \
+      libmcrypt-dev \
+      libmemcached-dev \
+      libmemcachedutil2 \
+      libpng-dev \
+      libpq-dev \
+      librabbitmq-dev \
+      libuv1-dev \
+      libwebp-dev \
+      libxml2-dev \
+      mcrypt \
+      multiarch-support \
+      "
 fi
 
 apt-get update \
@@ -89,8 +107,8 @@ apt-get update \
   && rm -rf /var/lib/apt/lists/* \
   && docker-php-ext-install -j$(nproc) $extensions
 
-if [[ $PHP_VERSION == "7.4" ]]; then
-    docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
+if [[ $PHP_VERSION == "8.0" || $PHP_VERSION == "7.4" ]]; then
+  docker-php-ext-configure gd --with-freetype --with-jpeg --with-webp \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
@@ -98,7 +116,7 @@ if [[ $PHP_VERSION == "7.4" ]]; then
     && docker-php-ext-install -j$(nproc) imap \
     && docker-php-source delete
 else
-    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include/ \
+  docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-webp-dir=/usr/include/ \
     && docker-php-ext-install -j$(nproc) gd \
     && docker-php-ext-configure ldap --with-libdir=lib/x86_64-linux-gnu/ \
     && docker-php-ext-install -j$(nproc) ldap \
@@ -107,7 +125,8 @@ else
     && docker-php-source delete
 fi
 
-docker-php-source extract \
+if ! [[ $PHP_VERSION == "8.0" ]]; then
+  docker-php-source extract \
     && curl -L -o /tmp/cassandra-cpp-driver.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver_2.14.0-1_amd64.deb" \
     && curl -L -o /tmp/cassandra-cpp-driver-dev.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver-dev_2.14.0-1_amd64.deb" \
     && dpkg -i /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
@@ -121,22 +140,65 @@ docker-php-source extract \
     && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \
     && docker-php-source delete
+fi
 
-if [[ $PHP_VERSION == "7.2" ]]; then
+if [[ $PHP_VERSION == "8.0" ]]; then
   docker-php-source extract \
     && git clone https://github.com/php-memcached-dev/php-memcached /usr/src/php/ext/memcached/ \
     && docker-php-ext-install memcached \
+    && docker-php-ext-enable memcached \
     && docker-php-source delete
 
   pecl channel-update pecl.php.net \
-    && pecl install amqp redis apcu mongodb imagick xdebug \
-    && docker-php-ext-enable amqp redis apcu mongodb imagick xdebug
+    && pecl install redis apcu mongodb xdebug \
+    && docker-php-ext-enable redis apcu mongodb xdebug
+
+  #AMQP
+  docker-php-source extract \
+    && mkdir /usr/src/php/ext/amqp \
+    && curl -L https://github.com/php-amqp/php-amqp/archive/master.tar.gz | tar -xzC /usr/src/php/ext/amqp --strip-components=1 \
+    && docker-php-ext-install amqp \
+    && docker-php-source delete
+
+  #Imagick
+  cd /usr/local/src \
+    && git clone https://github.com/Imagick/imagick \
+    && cd imagick \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf imagick \
+    && docker-php-ext-enable imagick
+
+  #XMLRPC
+  mkdir /usr/local/src/xmlrpc \
+    && cd /usr/local/src/xmlrpc \
+    && curl -L https://pecl.php.net/get/xmlrpc-1.0.0RC1.tgz | tar -xzC /usr/local/src/xmlrpc --strip-components=1 \
+    && phpize \
+    && ./configure \
+    && make \
+    && make install \
+    && cd .. \
+    && rm -rf xmlrpc \
+    && docker-php-ext-enable xmlrpc
 
 elif [[ $PHP_VERSION == "7.4" || $PHP_VERSION == "7.3" ]]; then
   docker-php-source extract \
     && git clone https://github.com/php-memcached-dev/php-memcached /usr/src/php/ext/memcached/ \
     && docker-php-ext-install memcached \
     && docker-php-ext-enable memcached \
+    && docker-php-source delete
+
+  pecl channel-update pecl.php.net \
+    && pecl install amqp redis apcu mongodb imagick xdebug \
+    && docker-php-ext-enable amqp redis apcu mongodb imagick xdebug
+
+elif [[ $PHP_VERSION == "7.2" ]]; then
+  docker-php-source extract \
+    && git clone https://github.com/php-memcached-dev/php-memcached /usr/src/php/ext/memcached/ \
+    && docker-php-ext-install memcached \
     && docker-php-source delete
 
   pecl channel-update pecl.php.net \
@@ -174,6 +236,12 @@ fi
 } > /usr/local/etc/php/conf.d/apcu-recommended.ini
 
 echo 'memory_limit=1024M' > /usr/local/etc/php/conf.d/zz-conf.ini
-echo 'xdebug.coverage_enable=1' > /usr/local/etc/php/conf.d/20-xdebug.ini
+
+if [[ $PHP_VERSION == "8.0" ]]; then
+  # https://xdebug.org/docs/upgrade_guide#changed-xdebug.coverage_enable
+  echo 'xdebug.mode=coverage' > /usr/local/etc/php/conf.d/20-xdebug.ini
+else
+  echo 'xdebug.coverage_enable=1' > /usr/local/etc/php/conf.d/20-xdebug.ini
+fi
 
 apt-get purge -yqq --auto-remove $buildDeps

--- a/tests/goss-8.0.yaml
+++ b/tests/goss-8.0.yaml
@@ -1,0 +1,92 @@
+---
+package:
+  curl:
+    installed: true
+  sudo:
+    installed: true
+
+command:
+  node --version:
+    exit-status: 0
+    stdout:
+      - "v14"
+  yarn --version:
+    exit-status: 0
+  npm --version:
+    exit-status: 0
+    stdout:
+      - "6"
+  sudo npm --version:
+    exit-status: 0
+  composer --version:
+    exit-status: 0
+  python3 --version:
+    exit-status: 0
+  make --version:
+    exit-status: 0
+  gcc --version:
+    exit-status: 0
+  g++ --version:
+    exit-status: 0
+  jq --version:
+    exit-status: 0
+  php -v:
+    exit-status: 0
+    stdout:
+      - "8.0"
+  php -m:
+    exit-status: 0
+    stdout:
+      - amqp
+      - apcu
+      - bcmath
+      - bz2
+      - calendar
+      - exif
+      - gd
+      - gmp
+      - iconv
+      - imagick
+      - imap
+      - intl
+      - ldap
+      - mbstring
+      - memcached
+      - mongodb
+      - mysqli
+      - OPcache
+      - pcntl
+      - pdo_mysql
+      - pdo_pgsql
+      - pgsql
+      - redis
+      - soap
+      - xdebug
+      - xml
+      - xmlrpc
+      - zip
+      - xsl
+
+file:
+  /usr/local/etc/php/conf.d/zz-conf.ini:
+    exists: true
+    contains:
+      - memory_limit
+  /usr/local/etc/php/conf.d/opcache-recommended.ini:
+    exists: true
+  /usr/local/etc/php/conf.d/apcu-recommended.ini:
+    exists: true
+  /home/php:
+    exists: true
+    owner: php
+  /home/php/.composer:
+    exists: true
+    owner: php
+  /home/php/.config:
+    exists: true
+    owner: php
+
+user:
+  php:
+    exists: true
+    home: /home/php


### PR DESCRIPTION
This PR adds PHP 8.0 support.  I don't normally submit competing PRs however I had this 95% complete when the other PR came through and this is passing all tests whereas the other PR is silently failing the build of some modules that are not compatible with PHP 8.  Significant changes are as follows:

### Build/Test Level Changes
-Added 8.0 Dockerfiles (cli, chromium, fpm, alpine, alpine-lts)
-Added 8.0 Goss test identical to 7.4 test but removing Cassandra extension that will not be supported in PHP 8

### PHP Internal Changes
-XMLRPC is removed from PHP core per [here](https://php.watch/versions/8.0/xmlrpc)
-PHP 8 requires xdebug 3.0 per [here](https://xdebug.org/docs/compat)
-PHP 8 requires phpredis 5.3 or higher per [here](https://github.com/phpredis/phpredis/issues/1809)
-Imagick extension supporting PHP 8 not yet released to PECL and installed from source per [here](https://github.com/Imagick/imagick/issues/358)
-AMQP extension supporting PHP 8 not yet released to PECL and installed from source per [here](https://github.com/php-amqp/php-amqp/issues/386)
-XMLRPC extension supporting PHP 8 PECL package is broken and installed from source per [here](https://bugs.php.net/bug.php?id=80618)
-Cassandra extension removed from PHP 8 builds due to no plans to support PHP 8 per [here](https://community.datastax.com/questions/9610/will-php-driver-be-updated-to-support-php-74-php-8.html)
-Xdebug 3 changes config settings for enable code coverage per [here](https://xdebug.org/docs/upgrade_guide#changed-xdebug.coverage_enable)

Note: At a future date a PR can be submitted to clean up/consolidate the build scripts once all these modules eventually make their way to PECL however building from source allows us to release a full feature PHP 8 image today.

### Testing the PR
All of the new PHP 8 images were built and are passing all tests.  I have also built and tested all PHP 7.2-7.4 images and ensured they are still passing all tests after modification of build scripts.

### Additional Notes
The other PR bumps Node, NPM, and Composer to latest version however I felt this was outside the scope of this PR and have not included.  I believe there is another PR already open for Composer or I am happy to submit additional PRs for these if needed in order to keep the scope of this change to PHP 8 only.


