### PR TITLE
Enable xdebug coverage in alpine images

### DIFF
--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -207,3 +207,10 @@ git clone "https://github.com/php-memcached-dev/php-memcached.git" \
 } > /usr/local/etc/php/conf.d/apcu-recommended.ini
 
 echo "memory_limit=1G" > /usr/local/etc/php/conf.d/zz-conf.ini
+
+if [[ $PHP_VERSION == "8.0" ]]; then
+  # https://xdebug.org/docs/upgrade_guide#changed-xdebug.coverage_enable
+  echo 'xdebug.mode=coverage' > /usr/local/etc/php/conf.d/20-xdebug.ini
+else
+  echo 'xdebug.coverage_enable=1' > /usr/local/etc/php/conf.d/20-xdebug.ini
+fi

--- a/tests/goss-7.2-3-lts.yaml
+++ b/tests/goss-7.2-3-lts.yaml
@@ -65,6 +65,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.coverage_enable
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:

--- a/tests/goss-7.2.yaml
+++ b/tests/goss-7.2.yaml
@@ -69,6 +69,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.coverage_enable
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:

--- a/tests/goss-7.3.yaml
+++ b/tests/goss-7.3.yaml
@@ -69,6 +69,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.coverage_enable
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:

--- a/tests/goss-7.4.yaml
+++ b/tests/goss-7.4.yaml
@@ -69,6 +69,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.coverage_enable
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:

--- a/tests/goss-8.0.yaml
+++ b/tests/goss-8.0.yaml
@@ -68,6 +68,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.mode
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:

--- a/tests/goss-lts.yaml
+++ b/tests/goss-lts.yaml
@@ -70,6 +70,10 @@ command:
       - xsl
 
 file:
+  /usr/local/etc/php/conf.d/20-xdebug.ini:
+    exists: true
+    contains:
+      - xdebug.coverage_enable
   /usr/local/etc/php/conf.d/zz-conf.ini:
     exists: true
     contains:


### PR DESCRIPTION
The xdebug ini file to enable coverage is missing in the alpine images, as it was not added in the `alpine/extensions.sh` script. In the PHP 7.4-alpine image this still seemed to be working (I'm not sure how), but in the new 8.0-alpine image code coverage did not work.

Also I added a test to check images for this file. I haven't been able to test all existing images yet with the new tests, but they work on the 7.4, 8.0 and 8.0-alpine images.