### PR TITLE
Fix xdebug coverage for 7.4-alpine

### DIFF
--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -176,7 +176,7 @@ git clone "https://github.com/php-memcached-dev/php-memcached.git" \
 
 echo "memory_limit=1G" > /usr/local/etc/php/conf.d/zz-conf.ini
 
-if [[ $PHP_VERSION == "8.0" ]]; then
+if [[ $PHP_VERSION == "8.0" || $PHP_VERSION == "7.4" ]]; then
   # https://xdebug.org/docs/upgrade_guide#changed-xdebug.coverage_enable
   echo 'xdebug.mode=coverage' > /usr/local/etc/php/conf.d/20-xdebug.ini
 else


### PR DESCRIPTION
Coverage isn't working in xdebug when using the 7.4-alpine image.

Basically the same thing as #116 but for alpine.