### PR TITLE
Replace cassandra's extension with fork to support PHP 8.0

### DIFF
--- a/php/scripts/alpine/extensions.sh
+++ b/php/scripts/alpine/extensions.sh
@@ -90,12 +90,11 @@ docker-php-source extract \
     && docker-php-source delete
 
 docker-php-source extract \
-    && apk add --no-cache --virtual .cassandra-deps libressl-dev libuv-dev cassandra-cpp-driver-dev \
-    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/24d85d9f1d.tar.gz" \
+    && apk add --no-cache --virtual .cassandra-deps openssl-dev libuv-dev cassandra-cpp-driver-dev \
+    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/nano-interactive/php-driver/archive/refs/tags/v1.3.3.tar.gz" \
     && mkdir /tmp/cassandra \
     && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
     && rm -r /tmp/cassandra.tar.gz \
-    && curl -L "https://github.com/datastax/php-driver/pull/135.patch" | patch -p1 -d /tmp/cassandra -i - \
     && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
     && rm -rf /tmp/cassandra \
     && docker-php-ext-install cassandra \

--- a/php/scripts/extensions.sh
+++ b/php/scripts/extensions.sh
@@ -96,22 +96,21 @@ else
     && docker-php-source delete
 fi
 
-if ! [[ $PHP_VERSION == "8.0" ]]; then
-  docker-php-source extract \
-    && curl -L -o /tmp/cassandra-cpp-driver.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver_2.14.0-1_amd64.deb" \
-    && curl -L -o /tmp/cassandra-cpp-driver-dev.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver-dev_2.14.0-1_amd64.deb" \
-    && dpkg -i /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
-    && rm /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
-    && curl -L -o /tmp/cassandra.tar.gz "https://github.com/datastax/php-driver/archive/24d85d9f1d.tar.gz" \
-    && mkdir /tmp/cassandra \
-    && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
-    && rm -r /tmp/cassandra.tar.gz \
-    && curl -L "https://github.com/datastax/php-driver/pull/135.patch" | patch -p1 -d /tmp/cassandra -i - \
-    && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
-    && rm -rf /tmp/cassandra \
-    && docker-php-ext-install cassandra \
-    && docker-php-source delete
+docker-php-source extract \
+  && curl -L -o /tmp/cassandra-cpp-driver.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver_2.14.0-1_amd64.deb" \
+  && curl -L -o /tmp/cassandra-cpp-driver-dev.deb "https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.14.0/cassandra-cpp-driver-dev_2.14.0-1_amd64.deb" \
+  && dpkg -i /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
+  && rm /tmp/cassandra-cpp-driver.deb /tmp/cassandra-cpp-driver-dev.deb \
+  && curl -L -o /tmp/cassandra.tar.gz "https://github.com/nano-interactive/php-driver/archive/refs/tags/v1.3.3.tar.gz" \
+  && mkdir /tmp/cassandra \
+  && tar xfz /tmp/cassandra.tar.gz --strip 1 -C /tmp/cassandra \
+  && rm -r /tmp/cassandra.tar.gz \
+  && mv /tmp/cassandra/ext /usr/src/php/ext/cassandra \
+  && rm -rf /tmp/cassandra \
+  && docker-php-ext-install cassandra \
+  && docker-php-source delete
 
+if ! [[ $PHP_VERSION == "8.0" ]]; then
   docker-php-source extract \
     && git clone https://github.com/php-memcached-dev/php-memcached /usr/src/php/ext/memcached/ \
     && docker-php-ext-install memcached \


### PR DESCRIPTION
Time to upgrade my projects to PHP 8.0 :)

The original developer of the extension has bailed on its support, but I found a fork, contacted the developers. Behind them is an organization that actively uses this extension, which guarantees support for the extension in the near future. I tested the build with PHP 8.0 and its stability on my working projects: no crashes have been found.