### PR TITLE
Use Consistent Docker Image Naming

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,9 +24,9 @@ Debian 8.0:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/$IMAGE_VERSION/Dockerfile .
-    - docker run -t --rm edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION -v
-    - docker run -t --rm edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION -m
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
+    - docker run -t --rm $NAMESPACE:$IMAGE_VERSION -v
+    - docker run -t --rm $NAMESPACE:$IMAGE_VERSION -m
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
     - docker tag $NAMESPACE:$IMAGE_VERSION $NAMESPACE:latest
     - docker tag $NAMESPACE:$IMAGE_VERSION $NAMESPACE:8
     - docker push $NAMESPACE:$IMAGE_VERSION
@@ -42,8 +42,8 @@ Debian 7.4:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/$IMAGE_VERSION/Dockerfile .
-    - docker run -t --rm edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION -m
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
+    - docker run -t --rm $NAMESPACE:$IMAGE_VERSION -m
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
     - docker tag $NAMESPACE:$IMAGE_VERSION $NAMESPACE:7
     - docker push $NAMESPACE:$IMAGE_VERSION
     - docker push $NAMESPACE:7
@@ -57,7 +57,7 @@ Debian 7.3:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/$IMAGE_VERSION/Dockerfile .
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-$IMAGE_VERSION.yaml v
     - docker push $NAMESPACE:$IMAGE_VERSION
 
   when: always
@@ -138,7 +138,6 @@ Alpine 7.3 LTS:
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
 
-
 FPM 8.0:
   stage: build
   variables:
@@ -165,7 +164,6 @@ FPM 7.4:
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
 
-
 FPM 7.3:
   stage: build
   variables:
@@ -178,7 +176,6 @@ FPM 7.3:
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
 
-
 Chromium 8.0:
   stage: build-chromium
   variables:
@@ -187,7 +184,7 @@ Chromium 8.0:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/8.0/chromium/Dockerfile .
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-8.0.yaml v
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-8.0.yaml v
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
   dependencies:
@@ -201,7 +198,7 @@ Chromium 7.4:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/7.4/chromium/Dockerfile .
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-7.4.yaml v
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-7.4.yaml v
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
   dependencies:
@@ -215,7 +212,7 @@ Chromium 7.3:
     - docker pull php:$IMAGE_VERSION || true
     - docker pull $NAMESPACE:$IMAGE_VERSION || true
     - docker build --compress --cache-from $NAMESPACE:$IMAGE_VERSION --build-arg VCS_REF=$CI_COMMIT_SHORT_SHA --build-arg BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ') -t $NAMESPACE:$IMAGE_VERSION -f php/7.3/chromium/Dockerfile .
-    - docker run -t --rm -v $(pwd):/var/www/html edbizarro/gitlab-ci-pipeline-php:$IMAGE_VERSION goss -g tests/goss-7.3.yaml v
+    - docker run -t --rm -v $(pwd):/var/www/html $NAMESPACE:$IMAGE_VERSION goss -g tests/goss-7.3.yaml v
     - docker push $NAMESPACE:$IMAGE_VERSION
   when: always
   dependencies:


### PR DESCRIPTION
This change aims to improve the consistency of Docker image naming conventions used in the CI/CD pipeline.

### Key Changes:
1.  Removed dependency on the edbizarro/gitlab-ci-pipeline-php image and replaced it with images from the internal namespace ($NAMESPACE).
2.  Standardized Docker image naming in the pipeline to:

    - Use a consistent format: $NAMESPACE:$IMAGE_VERSION.
    - Avoid duplication or naming conflicts during the build and tagging stages of the Docker image.

3.  Cleaned up the pipeline configuration by:

    - Eliminating redundant calls to edbizarro/gitlab-ci-pipeline-php.
    - Simplifying pipeline structure for easier maintenance.

### Reasons for the Change:

- Consistency: Uniform naming improves manageability and enhances pipeline readability.
- Simplicity: Reduces unnecessary configuration redundancies.
